### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ Commands
 ```console
 docker-compose stop
 docker-compose rm -fv
-docker-network rm wp-wordpress
+docker network rm wp-wordpress
 # removal calls may require sudo rights depending on file permissions
 rm -rf ./wordpress
 rm -rf ./dbdata


### PR DESCRIPTION
`docker-network` is not a valid docker command. It should be `docker network` as mentioned in the `expected output` section:

`$ docker network rm wp-wordpress`